### PR TITLE
fix: delay health check readiness until dependencies confirm

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -323,3 +323,4 @@ Running log of changes. Most recent at the bottom.
 [2026-05-17] reduce nesting
 [2026-05-19] node resource calculation
 [2026-05-19] fix: log level override not working
+[2026-05-20] fix: delay health check readiness until dependencies confirm


### PR DESCRIPTION
Modifies /healthz to return 503 until DB and cache connection checks pass. Transitions to 200 only after all dependency health checks succeed.