### PR TITLE
test: add chaos test for node drain under load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -323,3 +323,4 @@ Running log of changes. Most recent at the bottom.
 [2026-05-17] reduce nesting
 [2026-05-19] node resource calculation
 [2026-05-19] fix: log level override not working
+[2026-05-21] test: add chaos test for node drain under load


### PR DESCRIPTION
Simulates node drain while the cluster is under 80% CPU load and asserts pod rescheduling completes.